### PR TITLE
ci: enforce least-privilege permissions for GitHub Actions workflows

### DIFF
--- a/.github/workflows/image.yaml
+++ b/.github/workflows/image.yaml
@@ -8,6 +8,8 @@ on:
     tags:
       - 'v*'
 
+permissions: {}
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -8,6 +8,8 @@ on:
       - reopened
       - synchronize
 
+permissions: {}
+
 jobs:
   conventional-commit:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Enforce least-privilege permissions

This PR adds explicit `permissions` blocks to GitHub Actions workflow files that currently have no permissions defined, following the principle of least privilege.

### Changes
- `image.yaml`: permissions: {} (defense-in-depth)
- `pr.yaml`: permissions: {} (defense-in-depth)

### Why
Without explicit permissions, workflows inherit the default token permissions configured at the repository or organization level. By explicitly declaring the minimum required permissions, we reduce the blast radius if a workflow is compromised.

### References
- [GitHub Actions security hardening](https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions)
- [Automatic token authentication permissions](https://docs.github.com/en/actions/security-for-github-actions/security-guides/automatic-token-authentication#permissions-for-the-github_token)
